### PR TITLE
Unix dependency missing

### DIFF
--- a/src/interp/dune
+++ b/src/interp/dune
@@ -1,3 +1,3 @@
 (library
  (name interp)
- (libraries p smtlib parse check reduce))
+ (libraries p smtlib parse check reduce unix))


### PR DESCRIPTION
Resolves following issue
```
Error: No implementations provided for the following modules:
         Unix referenced from src/interp/interp.cmxa(Interp)
```